### PR TITLE
вывод description без тэгов

### DIFF
--- a/src/ymlOffer.php
+++ b/src/ymlOffer.php
@@ -129,7 +129,7 @@ class ymlOffer extends \DomElement
 			$desc->appendChild($cdata);
 			return $this;
 		}else{
-				return $this->add('description');
+				return $this->add('description', $txt);
 		}
 
 		


### PR DESCRIPTION
Description товарного предложения, в случае его вывода без тэгов, выводится пустым.